### PR TITLE
Expose the aliases of downloaded toolchan binaries for end-user consumption.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Tf rules are useful to validate, lint and format terraform code.
 
-They can typically be used in a terraform monorepo of modules to lint, run validation tests, auto generate documentation and enforce the consistency of providers versions across all modules.
+They can typically be used in a terraform monorepo of modules to lint, run validation tests, auto generate documentation and enforce the consistency of Tf and providers versions across all modules.
 
 # Why "Tf" and not "Terraform"
 
@@ -50,7 +50,9 @@ register_toolchains(
 )
 ```
 
-Once you've imported the rule set , you can then load the tf rules in your `BUILD` files with:
+### Using Tf rules
+
+Once you've imported the rule set, you can then load the tf rules in your `BUILD` files with:
 
 ```python
 load("@rules_tf//tf:def.bzl", "tf_providers_versions", "tf_module")
@@ -75,6 +77,20 @@ tf_module(
     providers_versions = ":providers",
 )
 ```
+
+### Using prebuilt binaries
+
+To ensure a consistent binary version across the team, you can create an alias to the prebuilt binaries:
+
+```python
+# Likewise for tofu, tfdoc, and tflint.
+alias(
+    name = "terraform",
+    actual = "@tf_toolchains//:terraform",
+)
+```
+
+And you can use `bazel run //:terraform` which uses the same version as configured in your `MODULE.bazel`.
 
 ## Using Tf Modules
 

--- a/tf/toolchains/terraform/BUILD.toolchain.tpl
+++ b/tf/toolchains/terraform/BUILD.toolchain.tpl
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-filegroup(
+alias(
     name = "runtime",
-    srcs = ["terraform/terraform"],
+    actual = "terraform/terraform",
     visibility = ["//visibility:public"]
 )
 

--- a/tf/toolchains/terraform/toolchain.bzl
+++ b/tf/toolchains/terraform/toolchain.bzl
@@ -105,4 +105,9 @@ toolchain(
   toolchain_type = "@rules_tf//:tf_toolchain_type",
   visibility = ["//visibility:public"],
 )
+
+alias(
+    name = "terraform",
+    actual = "@{toolchain_repo}//:runtime",
+)
 """

--- a/tf/toolchains/tfdoc/BUILD.toolchain.tpl
+++ b/tf/toolchains/tfdoc/BUILD.toolchain.tpl
@@ -2,8 +2,8 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files(["config.yaml"])
 
-filegroup(
+alias(
     name = "runtime",
-    srcs = ["terraform-docs/terraform-docs"],
-    visibility = ["//visibility:public"]
+    actual = "terraform-docs/terraform-docs",
+    visibility = ["//visibility:public"],
 )

--- a/tf/toolchains/tfdoc/toolchain.bzl
+++ b/tf/toolchains/tfdoc/toolchain.bzl
@@ -114,4 +114,9 @@ toolchain(
   toolchain_type = "@rules_tf//:tfdoc_toolchain_type",
   visibility = ["//visibility:public"],
 )
+
+alias(
+    name = "tfdoc",
+    actual = "@{toolchain_repo}//:runtime",
+)
 """

--- a/tf/toolchains/tflint/BUILD.toolchain.tpl
+++ b/tf/toolchains/tflint/BUILD.toolchain.tpl
@@ -2,8 +2,8 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files(["config.hcl", "wrapper.sh"])
 
-filegroup(
+alias(
     name = "runtime",
-    srcs = ["tflint/tflint"],
+    actual = "tflint/tflint",
     visibility = ["//visibility:public"]
 )

--- a/tf/toolchains/tflint/toolchain.bzl
+++ b/tf/toolchains/tflint/toolchain.bzl
@@ -134,4 +134,9 @@ toolchain(
   toolchain_type = "@rules_tf//:tflint_toolchain_type",
   visibility = ["//visibility:public"],
 )
+
+alias(
+    name = "tflint",
+    actual = "@{toolchain_repo}//:runtime",
+)
 """

--- a/tf/toolchains/tofu/BUILD.toolchain.tpl
+++ b/tf/toolchains/tofu/BUILD.toolchain.tpl
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
-filegroup(
+alias(
     name = "runtime",
-    srcs = ["tofu/tofu"],
+    actual = "tofu/tofu",
     visibility = ["//visibility:public"]
 )
 

--- a/tf/toolchains/tofu/toolchain.bzl
+++ b/tf/toolchains/tofu/toolchain.bzl
@@ -105,4 +105,9 @@ toolchain(
   toolchain_type = "@rules_tf//:tf_toolchain_type",
   visibility = ["//visibility:public"],
 )
+
+alias(
+    name = "tofu",
+    actual = "@{toolchain_repo}//:runtime",
+)
 """


### PR DESCRIPTION
The prime purpose of this is to have a single source of truth for the binary versions.