### PR TITLE
Updated the provider to support dictionary providers to support aliases

### DIFF
--- a/tests/bcr/tf/BUILD.bazel
+++ b/tests/bcr/tf/BUILD.bazel
@@ -2,7 +2,7 @@ load("@rules_tf//tf:def.bzl", "tf_providers_versions", "tf_format", "tf_gen_doc"
 
 tf_providers_versions(
     name = "versions",
-    tf_version = ">= 1.9, <= 1.10",
+    tf_version = ">= 1.9, <= 1.13",
     providers = {
         "random" : "hashicorp/random:3.3.2",
         "null"   : "hashicorp/null:3.1.1",

--- a/tests/bcr/tf/modules/mod-a/versions.tf.json
+++ b/tests/bcr/tf/modules/mod-a/versions.tf.json
@@ -1,1 +1,1 @@
-{"terraform":[{"required_providers":[{"random":{"source":"hashicorp/random","version":"3.3.2"}}],"required_version":">= 1.9, <= 1.10"}]}
+{"terraform":{"required_providers":{"random":{"source":"hashicorp/random","version":"3.3.2"}},"required_version":">= 1.9, <= 1.10"}}

--- a/tests/bcr/tf/modules/multi_provider/BUILD.bazel
+++ b/tests/bcr/tf/modules/multi_provider/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_tf//tf:def.bzl", "tf_module")
+
+tf_module(
+    name = "multi_provider",
+    providers = {
+        "random": {
+            "configuration_aliases": ["random.primary", "random.secondary"]
+        }
+    },
+    providers_versions = "//tf:versions",
+    tflint_config = "//tf:tflint-custom-config",
+    skip_validation = True,  # Nested module with provider aliases can't be validated standalone
+)

--- a/tests/bcr/tf/modules/multi_provider/README.md
+++ b/tests/bcr/tf/modules/multi_provider/README.md
@@ -1,0 +1,39 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9, <= 1.10 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | 3.3.2 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_random.primary"></a> [random.primary](#provider\_random.primary) | 3.3.2 |
+| <a name="provider_random.secondary"></a> [random.secondary](#provider\_random.secondary) | 3.3.2 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [random_string.primary](https://registry.terraform.io/providers/hashicorp/random/3.3.2/docs/resources/string) | resource |
+| [random_string.secondary](https://registry.terraform.io/providers/hashicorp/random/3.3.2/docs/resources/string) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_length"></a> [length](#input\_length) | Length of the random string | `number` | `8` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_primary_value"></a> [primary\_value](#output\_primary\_value) | The random string from primary provider |
+| <a name="output_secondary_value"></a> [secondary\_value](#output\_secondary\_value) | The random string from secondary provider |
+<!-- END_TF_DOCS -->

--- a/tests/bcr/tf/modules/multi_provider/main.tf
+++ b/tests/bcr/tf/modules/multi_provider/main.tf
@@ -1,0 +1,14 @@
+resource "random_string" "primary" {
+  length  = var.length
+  special = false
+}
+
+resource "random_string" "secondary" {
+  provider = random.secondary
+  length   = var.length
+  special  = false
+}
+
+provider "random" {
+  alias = "secondary"
+}

--- a/tests/bcr/tf/modules/multi_provider/main.tf
+++ b/tests/bcr/tf/modules/multi_provider/main.tf
@@ -8,7 +8,3 @@ resource "random_string" "secondary" {
   length   = var.length
   special  = false
 }
-
-provider "random" {
-  alias = "secondary"
-}

--- a/tests/bcr/tf/modules/multi_provider/outputs.tf
+++ b/tests/bcr/tf/modules/multi_provider/outputs.tf
@@ -1,0 +1,9 @@
+output "primary_value" {
+  description = "The random string from primary provider"
+  value       = random_string.primary.result
+}
+
+output "secondary_value" {
+  description = "The random string from secondary provider"
+  value       = random_string.secondary.result
+}

--- a/tests/bcr/tf/modules/multi_provider/variables.tf
+++ b/tests/bcr/tf/modules/multi_provider/variables.tf
@@ -1,0 +1,5 @@
+variable "length" {
+  description = "Length of the random string"
+  type        = number
+  default     = 8
+}

--- a/tests/bcr/tf/modules/multi_provider/versions.tf.json
+++ b/tests/bcr/tf/modules/multi_provider/versions.tf.json
@@ -1,0 +1,1 @@
+{"terraform":{"required_providers":{"random":{"configuration_aliases":["random.primary","random.secondary"],"source":"hashicorp/random","version":"3.3.2"}},"required_version":">= 1.9, <= 1.13"}}

--- a/tests/bcr/tf/root-modules/root-mod-multi-provider/BUILD.bazel
+++ b/tests/bcr/tf/root-modules/root-mod-multi-provider/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_tf//tf:def.bzl", "tf_module")
+
+tf_module(
+    name = "root-mod-multi-provider",
+    providers = [
+        "random",
+    ],
+    deps = [
+        "//tf/modules/multi_provider",
+    ],
+    providers_versions = "//tf:versions",
+    tflint_config = "//tf:tflint-custom-config",
+)

--- a/tests/bcr/tf/root-modules/root-mod-multi-provider/README.md
+++ b/tests/bcr/tf/root-modules/root-mod-multi-provider/README.md
@@ -1,0 +1,41 @@
+# Root Module - Multi-Provider Example
+
+This root module demonstrates how to use the `multi_provider` nested module with provider configuration aliases.
+
+## Architecture
+
+This example shows:
+1. **Root Module**: Defines concrete provider configurations (`random.primary` and `random.secondary`)
+2. **Nested Module**: Uses the multi_provider module which declares `configuration_aliases` 
+3. **Provider Mapping**: Maps the root module's provider instances to the nested module's aliases
+
+## Key Features
+
+- **Provider Aliases**: Demonstrates how to use the same provider type with different configurations
+- **Dictionary Format**: Shows the new dictionary format for providers with `configuration_aliases`
+- **Proper Validation**: The root module can be validated (unlike the nested module with aliases)
+
+## Usage
+
+The nested module (`//tf/modules/multi_provider`) uses the dictionary format:
+
+```python
+providers = {
+    "random": {
+        "configuration_aliases": ["random.primary", "random.secondary"]
+    }
+}
+```
+
+While this root module uses the standard string list format and provides concrete provider configurations:
+
+```python
+providers = [
+    "random",
+]
+```
+
+## Files Generated
+
+- `versions.tf.json`: Contains proper Terraform provider requirements with configuration aliases
+- Both modules generate their respective versions files with correct JSON structure

--- a/tests/bcr/tf/root-modules/root-mod-multi-provider/main.tf
+++ b/tests/bcr/tf/root-modules/root-mod-multi-provider/main.tf
@@ -1,0 +1,20 @@
+# Configure two provider instances for different purposes
+provider "random" {
+  alias = "primary"
+}
+
+provider "random" {
+  alias = "secondary"
+}
+
+# Use the multi_provider module with both provider configurations
+module "multi_provider_example" {
+  source = "../../modules/multi_provider"
+
+  providers = {
+    random.primary   = random.primary
+    random.secondary = random.secondary
+  }
+
+  length = 12
+}

--- a/tests/bcr/tf/root-modules/root-mod-multi-provider/outputs.tf
+++ b/tests/bcr/tf/root-modules/root-mod-multi-provider/outputs.tf
@@ -1,0 +1,9 @@
+output "primary_random" {
+  description = "Random string from primary provider"
+  value       = module.multi_provider_example.primary_value
+}
+
+output "secondary_random" {
+  description = "Random string from secondary provider"
+  value       = module.multi_provider_example.secondary_value
+}

--- a/tests/bcr/tf/root-modules/root-mod-multi-provider/variables.tf
+++ b/tests/bcr/tf/root-modules/root-mod-multi-provider/variables.tf
@@ -1,0 +1,1 @@
+# No input variables needed for this example

--- a/tests/bcr/tf/root-modules/root-mod-multi-provider/versions.tf.json
+++ b/tests/bcr/tf/root-modules/root-mod-multi-provider/versions.tf.json
@@ -1,0 +1,1 @@
+{"terraform":{"required_providers":{"random":{"source":"hashicorp/random","version":"3.3.2"}},"required_version":">= 1.9, <= 1.13"}}

--- a/tf/rules/tf-gen-versions.bzl
+++ b/tf/rules/tf-gen-versions.bzl
@@ -3,6 +3,7 @@ load("@rules_tf//tf/rules:providers.bzl", "TfProvidersVersionsInfo")
 def _impl(ctx):
     out_file = ctx.actions.declare_file(ctx.label.name + ".sh")
     providers = ctx.attr.providers
+    providers_dict_json = ctx.attr.providers_dict_json
     providers_versions = {}
     tf_version = ""
 
@@ -10,20 +11,44 @@ def _impl(ctx):
         providers_versions = ctx.attr.providers_versions[TfProvidersVersionsInfo].providers
         tf_version =  ctx.attr.providers_versions[TfProvidersVersionsInfo].tf_version
 
-    versions = {
-        "terraform": [
-            {
-                "required_providers": [dict([ (p, providers_versions[p])
-                                              for p in ctx.attr.providers if p in providers_versions ])],
-            }
-        ]
+    # Handle both string list and dict formats for providers
+    required_providers_dict = {}
+    
+    # Process string list format (legacy support)
+    if providers:
+        for p in providers:
+            if p in providers_versions:
+                required_providers_dict[p] = providers_versions[p]
+    
+    # Process dict format (new support for configuration aliases)
+    if providers_dict_json:
+        providers_dict = json.decode(providers_dict_json)
+        for provider_name, provider_config in providers_dict.items():
+            if provider_name in providers_versions:
+                provider_def = dict(providers_versions[provider_name])
+                
+                # Add configuration_aliases if specified
+                if "configuration_aliases" in provider_config:
+                    provider_def["configuration_aliases"] = provider_config["configuration_aliases"]
+                
+                required_providers_dict[provider_name] = provider_def
+            else:
+                # If not in providers_versions, still include it for alias-only configs
+                required_providers_dict[provider_name] = provider_config
+
+    terraform_block = {
+        "required_providers": required_providers_dict,
     }
 
     if tf_version != None and tf_version != "":
-        versions["terraform"][0]["required_version"] = tf_version
+        terraform_block["required_version"] = tf_version
 
     if ctx.attr.experiments != None and len(ctx.attr.experiments) > 0:
-        versions["terraform"][0]["experiments"] = ctx.attr.experiments
+        terraform_block["experiments"] = ctx.attr.experiments
+
+    versions = {
+        "terraform": terraform_block
+    }
 
     cmd = "printf '%s' '{json}' > ${{BUILD_WORKSPACE_DIRECTORY:-$PWD}}/{package}/versions.tf.json".format(
         json = json.encode(versions),
@@ -46,6 +71,7 @@ tf_gen_versions = rule(
     implementation = _impl,
     attrs = {
         "providers": attr.string_list(mandatory = False, default = []),
+        "providers_dict_json": attr.string(mandatory = False, default = ""),
         "experiments": attr.string_list(mandatory = False, default = []),
         "tf_version": attr.string(mandatory = False, default = ""),
         "providers_versions": attr.label(


### PR DESCRIPTION
Closes issue described in #15 

This PR adds support for provider configuration aliases in Terraform modules by extending the providers parameter to accept both string lists and dictionaries (new). This enables multi-provider scenarios like multi-region deployments where a module needs multiple instances of the same provider.

## Key Changes

### 1. TF_MODULE schema update
the tf_module now supports providers as the existing list format, and also as a nested map to allow configuration_aliases. This then allows for versions.tf.json files to be generated with configuration_aliases.

### 2. Validation Handling for Nested Modules

Added `skip_validation` parameter for modules with configuration aliases that cannot be validated standalone (such as described here https://discuss.hashicorp.com/t/validating-modules-which-have-configuration-aliases/46056/11)
