### PR TITLE
feat: Support downloading tflint plugins

### DIFF
--- a/tf/extensions.bzl
+++ b/tf/extensions.bzl
@@ -74,10 +74,10 @@ def _tf_repositories(ctx):
                 version = version_tag.tflint_version,
                 os = host_detected_os,
                 arch = host_detected_arch,
+                config = version_tag.tflint_config,
             )
 
             tflint_toolchains += [tflint_repo_name]
-
 
             if version_tag.use_tofu:
                 tofu_download(
@@ -113,6 +113,11 @@ _version_tag = tag_class(
         "use_tofu": attr.bool(default = False),
         "version": attr.string(mandatory = True),
         "tflint_version": attr.string(default = TFLINT_VERSION),
+        "tflint_config": attr.label(
+            default = "@rules_tf//tf/toolchains/tflint:config.hcl",
+            allow_single_file = True,
+            cfg = "target",
+        ),
         "tfdoc_version": attr.string(default = TFDOC_VERSION),
         "mirror": attr.string_dict(mandatory = True),
     },

--- a/tf/toolchains/tflint/BUILD.toolchain.tpl
+++ b/tf/toolchains/tflint/BUILD.toolchain.tpl
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-exports_files(["config.hcl", "wrapper.sh"])
+exports_files(["config.hcl", "wrapper.sh", "tflint_plugins"])
 
 alias(
     name = "runtime",

--- a/tf/toolchains/tflint/toolchain.bzl
+++ b/tf/toolchains/tflint/toolchain.bzl
@@ -2,7 +2,7 @@ load("@rules_tf//tf/toolchains:utils.bzl", "get_sha256sum")
 
 TflintInfo = provider(
     doc = "Information about how to invoke tflint.",
-    fields = ["runner", "deps", "config"],
+    fields = ["runner", "deps", "config", "tflint_plugins"],
 )
 
 def _tflint_toolchain_impl(ctx):
@@ -10,10 +10,12 @@ def _tflint_toolchain_impl(ctx):
         runtime = TflintInfo(
             runner = ctx.file.wrapper,
             config = ctx.file.config,
+            tflint_plugins = ctx.file.tflint_plugins,
             deps = ctx.files.bash_tools + [
                 ctx.file.wrapper,
                 ctx.file.config,
                 ctx.file.tflint,
+                ctx.file.tflint_plugins,
             ],
         ),
     )
@@ -43,6 +45,11 @@ tflint_toolchain = rule(
             mandatory = False,
             default = "@bazel_tools//tools/bash/runfiles",
             allow_files = True,
+            cfg = "target",
+        ),
+        "tflint_plugins": attr.label(
+            mandatory = True,
+            allow_single_file = True,
             cfg = "target",
         ),
     },
@@ -100,6 +107,12 @@ def _tflint_download_impl(ctx):
     if not res.success:
         fail("!failed to dl: ", url)
 
+    res = ctx.execute([
+        "bash",
+        "-c",
+        "mkdir -p tflint_plugins; TFLINT_PLUGIN_DIR=./tflint_plugins tflint/tflint -c ./config.hcl --init",
+    ])
+
     return
 
 tflint_download = repository_rule(
@@ -117,13 +130,13 @@ tflint_download = repository_rule(
     },
 )
 
-
 DECLARE_TOOLCHAIN_CHUNK = """
 tflint_toolchain(
    name = "{toolchain_repo}_toolchain_impl",
    tflint = "@{toolchain_repo}//:runtime",
    config = "@{toolchain_repo}//:config.hcl",
    wrapper = "@{toolchain_repo}//:wrapper.sh",
+   tflint_plugins = "@{toolchain_repo}//:tflint_plugins",
 )
 
 toolchain(

--- a/tf/toolchains/tflint/wrapper.sh
+++ b/tf/toolchains/tflint/wrapper.sh
@@ -23,4 +23,6 @@ if [[ ! -f "${TFLINT_CONFIG_FILE}" ]]; then
     exit 1
 fi
 
+export TFLINT_PLUGIN_DIR="${TFLINT_DIR}/tflint_plugins"
+
 exec "${TFLINT_DIR}/tflint/tflint" --chdir="$WORKDIR" --config="${TFLINT_CONFIG_FILE}" "$@"


### PR DESCRIPTION
[tflint](https://github.com/terraform-linters/tflint/tree/master) provides a plugin system to introduce provider specific linting rules. ex: https://github.com/terraform-linters/tflint-ruleset-aws.

These plugins are downloaded by defining them on the tflint config and running `tflint --init` step.

Similar to how terraform plugins are downloaded with `mirror` command, the  tflint's `--init` flag allows defining a plugin directory via `TFLINT_PLUGIN_DIR` env variable.

This PR extends the functionality of the tflint toolchain to exetute tflint with `--init` flag to pre-cache the plugins on a predefined directory. `wrapper.sh` scripts sets the `TFLINT_PLUGIN_DIR` to use the pre-cached plugins duing lint runs.

